### PR TITLE
fix: missing exchange key & value in gtt_get_orders.json

### DIFF
--- a/gtt_get_orders.json
+++ b/gtt_get_orders.json
@@ -54,6 +54,7 @@
             },
             "orders": [
                 {
+                    "exchange": "NSE",
                     "tradingsymbol": "RAIN",
                     "product": "CNC",
                     "order_type": "LIMIT",


### PR DESCRIPTION
The `gtt_get_orders.json` Orders Array First Element had missing `exchange` key and value, hence added it at line 57 as `"exchange": "NSE"`