### PR TITLE
feat: update autoslice response to v2 format

### DIFF
--- a/autoslice_response.json
+++ b/autoslice_response.json
@@ -1,25 +1,25 @@
 {
   "status": "success",
-  "data": [
-    {
-      "order_id": "1914227164488687616"
-    },
-    {
-      "order_id": "1914227164534824960"
-    },
-    {
-      "order_id": "1914227164580962304"
-    },
-    {
-      "error": {
-        "code": 400,
-        "error_type": "MarginException",
-        "message": "Insufficient funds. Required margin is 228365.92 but available margin is 228358.50.",
-        "data": null
+  "data": {
+    "order_id": "1914227164488687616",
+    "children": [
+      {
+        "order_id": "1914227164534824960"
+      },
+      {
+        "order_id": "1914227164580962304"
+      },
+      {
+        "error": {
+          "code": 400,
+          "error_type": "MarginException",
+          "message": "Insufficient funds. Required margin is 228365.92 but available margin is 228358.50.",
+          "data": null
+        }
+      },
+      {
+        "order_id": "1914227164681625600"
       }
-    },
-    {
-      "order_id": "1914227164681625600"
-    }
-  ]
+    ]
+  }
 }


### PR DESCRIPTION
Update the autoslice order response mock from the old flat array format to the new v2 format with parent order_id and children array.

**Old format:** `data` is an array of order_ids/errors
**New format:** `data` is an object with `order_id` (parent) and `children` array

This matches the API change going live on 27th March 2026.

Related: zerodha/gokiteconnect#123